### PR TITLE
Updated paging_extras to take optional is_endless variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build
 .DS_Store
 /dist
+.idea/*

--- a/paging/templatetags/paging_extras.py
+++ b/paging/templatetags/paging_extras.py
@@ -25,14 +25,18 @@ if is_coffin:
         return dict(objects=context['paginator'].get('objects', []), paging=paging)
     register.object(paginate)
 
-@tag(register, [Variable('queryset_or_list'), Constant('from'), Variable('request'), Optional([Constant('as'), Name('asvar')]), Optional([Constant('per_page'), Variable('per_page')])])
-def paginate(context, queryset_or_list, request, asvar, per_page=25):
-    """{% paginate queryset_or_list from request as foo[ per_page 25] %}"""
+@tag(register, [Variable('queryset_or_list'),
+                Constant('from'), Variable('request'),
+                Optional([Constant('as'), Name('asvar')]),
+                Optional([Constant('per_page'), Variable('per_page')]),
+                Optional([Variable('is_endless')])])
+def paginate(context, queryset_or_list, request, asvar, per_page=25, is_endless=True):
+    """{% paginate queryset_or_list from request as foo[ per_page 25][ is_endless False %}"""
     
     from django.template.loader import render_to_string
 
     context_instance = RequestContext(request)
-    paging_context = paginate_func(request, queryset_or_list, per_page)
+    paging_context = paginate_func(request, queryset_or_list, per_page, endless=is_endless)
     paging = mark_safe(render_to_string('paging/pager.html', paging_context, context_instance))
 
     result = dict(objects=paging_context['paginator'].get('objects', []), paging=paging)


### PR DESCRIPTION
I needed to use the paging_extras templatetag with the BetterPaginator vs. the EndlessPaginator.  I updated the templatetag to take an optional is_endless variable, which by default is set to True, to allow the use of the BetterPaginator on the paginate_func call.

There was an issue already open for this as well: https://github.com/dcramer/django-paging/issues/#issue/2
