### PR TITLE
added paginator object to tag output for use in template

### DIFF
--- a/paging/templatetags/paging_extras.py
+++ b/paging/templatetags/paging_extras.py
@@ -5,12 +5,12 @@ from django.utils.safestring import mark_safe
 from django.template import RequestContext
 
 try:
-    from coffin import template
-    from coffin.shortcuts import render_to_string
-    from jinja2 import Markup
-    is_coffin = True
+	from coffin import template
+	from coffin.shortcuts import render_to_string
+	from jinja2 import Markup
+	is_coffin = True
 except ImportError:
-    is_coffin = False
+	is_coffin = False
 
 from templatetag_sugar.register import tag
 from templatetag_sugar.parser import Name, Variable, Constant, Optional, Model
@@ -18,29 +18,29 @@ from templatetag_sugar.parser import Name, Variable, Constant, Optional, Model
 register = template.Library()
 
 if is_coffin:
-    def paginate(request, queryset_or_list, per_page=25):
-        context_instance = RequestContext(request)
-        context = paginate_func(request, queryset_or_list, per_page)
-        paging = Markup(render_to_string('paging/pager.html', context, context_instance))
-        return dict(objects=context['paginator'].get('objects', []), paging=paging)
-    register.object(paginate)
+	def paginate(request, queryset_or_list, per_page=25):
+		context_instance = RequestContext(request)
+		context = paginate_func(request, queryset_or_list, per_page)
+		paging = Markup(render_to_string('paging/pager.html', context, context_instance))
+		return dict(objects=context['paginator'].get('objects', []), paging=paging)
+	register.object(paginate)
 
 @tag(register, [Variable('queryset_or_list'),
-                Constant('from'), Variable('request'),
-                Optional([Constant('as'), Name('asvar')]),
-                Optional([Constant('per_page'), Variable('per_page')]),
-                Optional([Variable('is_endless')])])
+				Constant('from'), Variable('request'),
+				Optional([Constant('as'), Name('asvar')]),
+				Optional([Constant('per_page'), Variable('per_page')]),
+				Optional([Variable('is_endless')])])
 def paginate(context, queryset_or_list, request, asvar, per_page=25, is_endless=True):
-    """{% paginate queryset_or_list from request as foo[ per_page 25][ is_endless False %}"""
-    
-    from django.template.loader import render_to_string
+	"""{% paginate queryset_or_list from request as foo[ per_page 25][ is_endless False %}"""
 
-    context_instance = RequestContext(request)
-    paging_context = paginate_func(request, queryset_or_list, per_page, endless=is_endless)
-    paging = mark_safe(render_to_string('paging/pager.html', paging_context, context_instance))
+	from django.template.loader import render_to_string
 
-    result = dict(objects=paging_context['paginator'].get('objects', []), paging=paging)
-    if asvar:
-        context[asvar] = result
-        return ''
-    return result
+	context_instance = RequestContext(request)
+	paging_context = paginate_func(request, queryset_or_list, per_page, endless=is_endless)
+	paging = mark_safe(render_to_string('paging/pager.html', paging_context, context_instance))
+
+	result = dict(objects=paging_context['paginator'].get('objects', []), paging=paging, paginator=paging_context['paginator'])
+	if asvar:
+		context[asvar] = result
+		return ''
+	return result

--- a/paging/templatetags/paging_extras.py
+++ b/paging/templatetags/paging_extras.py
@@ -5,12 +5,12 @@ from django.utils.safestring import mark_safe
 from django.template import RequestContext
 
 try:
-	from coffin import template
-	from coffin.shortcuts import render_to_string
-	from jinja2 import Markup
-	is_coffin = True
+    from coffin import template
+    from coffin.shortcuts import render_to_string
+    from jinja2 import Markup
+    is_coffin = True
 except ImportError:
-	is_coffin = False
+    is_coffin = False
 
 from templatetag_sugar.register import tag
 from templatetag_sugar.parser import Name, Variable, Constant, Optional, Model
@@ -18,29 +18,29 @@ from templatetag_sugar.parser import Name, Variable, Constant, Optional, Model
 register = template.Library()
 
 if is_coffin:
-	def paginate(request, queryset_or_list, per_page=25):
-		context_instance = RequestContext(request)
-		context = paginate_func(request, queryset_or_list, per_page)
-		paging = Markup(render_to_string('paging/pager.html', context, context_instance))
-		return dict(objects=context['paginator'].get('objects', []), paging=paging)
-	register.object(paginate)
+    def paginate(request, queryset_or_list, per_page=25):
+        context_instance = RequestContext(request)
+        context = paginate_func(request, queryset_or_list, per_page)
+        paging = Markup(render_to_string('paging/pager.html', context, context_instance))
+        return dict(objects=context['paginator'].get('objects', []), paging=paging)
+    register.object(paginate)
 
 @tag(register, [Variable('queryset_or_list'),
-				Constant('from'), Variable('request'),
-				Optional([Constant('as'), Name('asvar')]),
-				Optional([Constant('per_page'), Variable('per_page')]),
-				Optional([Variable('is_endless')])])
+                Constant('from'), Variable('request'),
+                Optional([Constant('as'), Name('asvar')]),
+                Optional([Constant('per_page'), Variable('per_page')]),
+                Optional([Variable('is_endless')])])
 def paginate(context, queryset_or_list, request, asvar, per_page=25, is_endless=True):
-	"""{% paginate queryset_or_list from request as foo[ per_page 25][ is_endless False %}"""
+    """{% paginate queryset_or_list from request as foo[ per_page 25][ is_endless False %}"""
 
-	from django.template.loader import render_to_string
+    from django.template.loader import render_to_string
 
-	context_instance = RequestContext(request)
-	paging_context = paginate_func(request, queryset_or_list, per_page, endless=is_endless)
-	paging = mark_safe(render_to_string('paging/pager.html', paging_context, context_instance))
+    context_instance = RequestContext(request)
+    paging_context = paginate_func(request, queryset_or_list, per_page, endless=is_endless)
+    paging = mark_safe(render_to_string('paging/pager.html', paging_context, context_instance))
 
-	result = dict(objects=paging_context['paginator'].get('objects', []), paging=paging, paginator=paging_context['paginator'])
-	if asvar:
-		context[asvar] = result
-		return ''
-	return result
+    result = dict(objects=paging_context['paginator'].get('objects', []), paging=paging, paginator=paging_context['paginator'])
+    if asvar:
+        context[asvar] = result
+        return ''
+    return result

--- a/paging/templatetags/paging_extras.py
+++ b/paging/templatetags/paging_extras.py
@@ -39,7 +39,8 @@ def paginate(context, queryset_or_list, request, asvar, per_page=25, is_endless=
     paging_context = paginate_func(request, queryset_or_list, per_page, endless=is_endless)
     paging = mark_safe(render_to_string('paging/pager.html', paging_context, context_instance))
 
-    result = dict(objects=paging_context['paginator'].get('objects', []), paging=paging, paginator=paging_context['paginator'])
+    result = dict(objects=paging_context['paginator'].get('objects', []),
+				  paging=paging, paginator=paging_context['paginator'])
     if asvar:
         context[asvar] = result
         return ''


### PR DESCRIPTION
I needed to customize the pagination nav, so I added the paging_context['paginator'] to the tag output as 'paginator'.  This allows one to access stuff like next_page.  
